### PR TITLE
Replaced ProgressBarAndroid with ActivityIndicator

### DIFF
--- a/image.js
+++ b/image.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Image, ProgressBarAndroid } from 'react-native';
+import { Image, ActivityIndicator } from 'react-native';
 import RNFS, { DocumentDirectoryPath } from 'react-native-fs';
 import ResponsiveImage from 'react-native-responsive-image';
 
@@ -134,7 +134,7 @@ class CacheableImage extends React.Component {
         }
 
         return (
-            <ProgressBarAndroid  />
+            <ActivityIndicator  />
         );
     }
 


### PR DESCRIPTION
Hi,

As latest versions of React gives warning on calculated props, as used in ProgressBarAndroid on "indeterminate" prop, I replaced ProgressBarAndroid with ActivityIndicator.

react-native-cacheable-image uses ProgressBarIndicator without progress indication, it seems that it can be replaced with ActivityIndicator, which always has an indeterminate progress.

Regards.
