### PR TITLE
Added support for defaultSource prop

### DIFF
--- a/image.js
+++ b/image.js
@@ -133,17 +133,13 @@ class CacheableImage extends React.Component {
             return this.renderCache();
         }
 
-		if (this.props.defaultSource) {
-			return (
-				<ResponsiveImage {...this.props} source={this.props.defaultSource}>
-	            {this.props.children}
-	            </ResponsiveImage>
-			);
-		} else {
-	        return (
-	            <ActivityIndicator  />
-	        );
-		}
+        if (this.props.defaultSource) {
+            return this.renderDefaultSource();
+        }
+
+        return (
+            <ActivityIndicator  />
+        );
     }
 
     renderCache() {
@@ -157,6 +153,14 @@ class CacheableImage extends React.Component {
     renderLocal() {
         return (
             <ResponsiveImage {...this.props} >
+            {this.props.children}
+            </ResponsiveImage>
+        );
+    }
+
+    renderDefaultSource() {
+        return (
+            <ResponsiveImage {...this.props} source={this.props.defaultSource}>
             {this.props.children}
             </ResponsiveImage>
         );

--- a/image.js
+++ b/image.js
@@ -133,9 +133,17 @@ class CacheableImage extends React.Component {
             return this.renderCache();
         }
 
-        return (
-            <ActivityIndicator  />
-        );
+		if (this.props.defaultSource) {
+			return (
+				<ResponsiveImage {...this.props} source={this.props.defaultSource}>
+	            {this.props.children}
+	            </ResponsiveImage>
+			);
+		} else {
+	        return (
+	            <ActivityIndicator  />
+	        );
+		}
     }
 
     renderCache() {


### PR DESCRIPTION
I found that I wanted to use a placeholder image instead of a spinner for the time between requesting and loading the image, and also for images that could not be loaded. This PR adds support for a defaultSource prop that is used instead of ActivityIndicator if it is specified.
