### PR TITLE
Added a file size check in checkImageCache

### DIFF
--- a/image.js
+++ b/image.js
@@ -45,10 +45,12 @@ class CacheableImage extends React.Component {
         RNFS
         .stat(filePath)
         .then((res) => {
-            if (res.isFile()) {
+            if (res.isFile() && res.size > 0) {
                 // means file exists, ie, cache-hit
                 this.setState({cacheable: true, cachedImagePath: filePath});
-            }
+            } else {
+				throw new Error("checkImageCache: Image is not a nonempty file");
+			}
         })
         .catch((err) => {
             // means file does not exist


### PR DESCRIPTION
As I was developing my application, I found that if an image failed to download for whatever reason (network offline, for example), the image was saved as a zero byte file. This lead to blank images in my UI.

I added a check to checkImageCache() that makes sure the cached file is greater than 0 bytes. If it is zero bytes, it throws an error to trigger another download attempt.
