### PR TITLE
Fix cached images on iOS

### DIFF
--- a/image.js
+++ b/image.js
@@ -143,8 +143,8 @@ class CacheableImage extends React.Component {
             }
             
             // ignore extension
-            // const type = url.pathname.replace(/.*\.(.*)/, '$1');
-            const cacheKey = SHA1(cacheable); // +'.'+type;
+            const type = url.pathname.replace(/.*\.(.*)/, '$1');
+            const cacheKey = SHA1(cacheable) + '.' + (type.length < url.pathname.length ? type : '');
 
             this.checkImageCache(source.uri, url.host, cacheKey);
             this.setState({isRemote: true});


### PR DESCRIPTION
iOS was not rendering images without an extension because it expects the files to be PNG. This PR re-enables the extension for cached files, if an extension is available.

I expect that this fixes #23