### PR TITLE
Fixes to displaying static images

### DIFF
--- a/image.js
+++ b/image.js
@@ -226,7 +226,7 @@ class CacheableImage extends React.Component {
 
 CacheableImage.propTypes = {
     activityIndicatorProps: React.PropTypes.object,
-    defaultSource: React.PropTypes.object,
+    defaultSource: Image.propTypes.source,
     useQueryParamsInCacheKey: React.PropTypes.oneOfType([
         React.PropTypes.bool,
         React.PropTypes.array

--- a/image.js
+++ b/image.js
@@ -179,7 +179,7 @@ class CacheableImage extends React.Component {
     };
   
     render() {        
-        if (!this.state.isRemote && !this.state.cacheable) {
+        if (!this.state.isRemote) {
             return this.renderLocal();
         }
 


### PR DESCRIPTION
This solves two problems:

1. Static image resources passed to defaultSource were being marked as invalid because they are not Objects. This was solved by using the propType validator from the Image component.
2. Static image resources passed to source or defaultSource were not being displayed because this.state.cacheable was set to true, and render() was checking to see if this was false.