### PR TITLE
setState warnings, Broken Images, & Race Conditions

### DIFF
--- a/image.js
+++ b/image.js
@@ -14,19 +14,23 @@ class CacheableImage extends React.Component {
         this.imageDownloadBegin = this.imageDownloadBegin.bind(this);
         this.imageDownloadProgress = this.imageDownloadProgress.bind(this);
         this._handleConnectivityChange = this._handleConnectivityChange.bind(this);
-        
+        this._stopDownload = this._stopDownload.bind(this);
+
         this.state = {
             isRemote: false,
             cachedImagePath: null,
-            downloading: false,
             cacheable: true,
-            jobId: null,
             networkAvailable: props.networkAvailable
         };
+
+        this.downloading = false;
+        this.jobId = null;
     };
 
     componentWillReceiveProps(nextProps) {
-        if (nextProps.source != this.props.source) {
+        if (nextProps.source != this.props.source
+            && nextProps.source.hasOwnProperty('uri') && this.props.source.hasOwnProperty('uri')
+            && nextProps.source.uri != this.props.source.uri) {
             this._processSource(nextProps.source);
         }
     }
@@ -37,14 +41,16 @@ class CacheableImage extends React.Component {
         }
         return true;
     }
-    
+
     async imageDownloadBegin(info) {
-        this.setState({downloading: true, jobId: info.jobId});
+        this.downloading = true;
+        this.jobId = info.jobId;
     }
 
     async imageDownloadProgress(info) {
         if ((info.contentLength / info.bytesWritten) == 1) {
-            this.setState({downloading: false, jobId: null});
+            this.downloading = false;
+            this.jobId = null;
         }
     }
 
@@ -55,20 +61,22 @@ class CacheableImage extends React.Component {
         RNFS
         .stat(filePath)
         .then((res) => {
-            if (res.isFile()) {
+            if (res.isFile() && res.size > 0) {
                 // means file exists, ie, cache-hit
                 this.setState({cacheable: true, cachedImagePath: filePath});
+            } else {
+                throw Error("CacheableImage: Invalid file in checkImageCache()");
             }
         })
         .catch((err) => {
-        
+
             // means file does not exist
             // first make sure network is available..
             if (! this.state.networkAvailable) {
                 this.setState({cacheable: false, cachedImagePath: null});
                 return;
             }
-                        
+
             // then make sure directory exists.. then begin download
             // The NSURLIsExcludedFromBackupKey property can be provided to set this attribute on iOS platforms.
             // Apple will reject apps for storing offline cache data that does not have this attribute.
@@ -79,7 +87,12 @@ class CacheableImage extends React.Component {
                 // before we change the cachedImagePath.. if the previous cachedImagePath was set.. remove it
                 if (this.state.cacheable && this.state.cachedImagePath) {
                     let delImagePath = this.state.cachedImagePath;
-                    this.deleteFilePath(delImagePath);
+                    this._deleteFilePath(delImagePath);
+                }
+
+                // If already downloading, cancel the job
+                if (this.jobId) {
+                    this._stopDownload();
                 }
 
                 let downloadOptions = {
@@ -91,16 +104,28 @@ class CacheableImage extends React.Component {
                 };
 
                 // directory exists.. begin download
-                RNFS
-                .downloadFile(downloadOptions)
-                .promise
+                let download = RNFS
+                .downloadFile(downloadOptions);
+
+                this.downloading = true;
+                this.jobId = download.jobId;
+
+                download.promise
                 .then(() => {
+                    this.downloading = false;
+                    this.jobId = null;
                     this.setState({cacheable: true, cachedImagePath: filePath});
                 })
                 .catch((err) => {
                     // error occurred while downloading or download stopped.. remove file if created
                     this._deleteFilePath(filePath);
-                    this.setState({cacheable: false, cachedImagePath: null});
+
+                    // If there was no in-progress job, it may have been cancelled already (and this component may be unmounted)
+                    if (this.downloading) {
+                        this.downloading = false;
+                        this.jobId = null;
+                        this.setState({cacheable: false, cachedImagePath: null});
+                    }
                 });
             })
             .catch((err) => {
@@ -121,7 +146,7 @@ class CacheableImage extends React.Component {
             }
         });
     }
-    
+
     _processSource(source) {
         if (source !== null
 		    && source != ''
@@ -129,20 +154,20 @@ class CacheableImage extends React.Component {
             && source.hasOwnProperty('uri'))
         { // remote
             const url = new URL(source.uri, null, true);
-            
+
             // handle query params for cache key
             let cacheable = url.pathname;
             if (Array.isArray(this.props.useQueryParamsInCacheKey)) {
                 this.props.useQueryParamsInCacheKey.forEach(function(k) {
                     if (url.query.hasOwnProperty(k)) {
                         cacheable = cacheable.concat(url.query[k]);
-                    }    
-                });                
+                    }
+                });
             }
             else if (this.props.useQueryParamsInCacheKey) {
                 cacheable = cacheable.concat(url.query);
             }
-            
+
             // ignore extension
             const type = url.pathname.replace(/.*\.(.*)/, '$1');
             const cacheKey = SHA1(cacheable) + '.' + (type.length < url.pathname.length ? type : '');
@@ -155,21 +180,31 @@ class CacheableImage extends React.Component {
         }
     }
 
+    _stopDownload() {
+        if (!this.jobId) return;
+
+        this.downloading = false;
+        RNFS.stopDownload(this.jobId);
+        this.jobId = null;
+    }
+
     componentWillMount() {
         NetInfo.isConnected.addEventListener('change', this._handleConnectivityChange);
-        
-	if (this.props.checkNetwork) {
-            NetInfo.isConnected.fetch().done(this._handleConnectivityChange);
+
+        if (this.props.checkNetwork) {
+            // componentWillUnmount unsets this._handleConnectivityChange in case the component unmounts before this fetch resolves
+            NetInfo.isConnected.fetch().done((isConnected) => this._handleConnectivityChange && this._handleConnectivityChange(isConnected));
         }
-        
+
         this._processSource(this.props.source);
     }
 
     componentWillUnmount() {
         NetInfo.isConnected.removeEventListener('change', this._handleConnectivityChange);
-    
-        if (this.state.downloading && this.state.jobId) {
-            RNFS.stopDownload(this.state.jobId);
+        this._handleConnectivityChange = null;
+
+        if (this.downloading && this.jobId) {
+            this._stopDownload();
         }
     }
 
@@ -178,8 +213,8 @@ class CacheableImage extends React.Component {
             networkAvailable: isConnected,
 	    });
     };
-  
-    render() {        
+
+    render() {
         if (!this.state.isRemote) {
             return this.renderLocal();
         }
@@ -187,7 +222,7 @@ class CacheableImage extends React.Component {
         if (this.state.cacheable && this.state.cachedImagePath) {
             return this.renderCache();
         }
-        
+
         if (this.props.defaultSource) {
             return this.renderDefaultSource();
         }
@@ -216,8 +251,7 @@ class CacheableImage extends React.Component {
     }
 
     renderDefaultSource() {
-        const { children, defaultSource, ...props } = this.props;
-	const { children, defaultSource, checkNetwork, ...props } = this.props;
+        const { children, defaultSource, checkNetwork, ...props } = this.props;
         const { networkAvailable } = this.state;
         return (
             <CacheableImage {...props} source={defaultSource} checkNetwork={false} networkAvailable={networkAvailable} >

--- a/image.js
+++ b/image.js
@@ -21,7 +21,7 @@ class CacheableImage extends React.Component {
             downloading: false,
             cacheable: true,
             jobId: null,
-            networkAvailable: false
+            networkAvailable: props.networkAvailable
         };
     };
 
@@ -157,10 +157,10 @@ class CacheableImage extends React.Component {
 
     componentWillMount() {
         NetInfo.isConnected.addEventListener('change', this._handleConnectivityChange);
-        // initial
-        NetInfo.isConnected.fetch().then(isConnected => {
-            this.setState({networkAvailable: isConnected});
-		});
+        
+	if (this.props.checkNetwork) {
+            NetInfo.isConnected.fetch().done(this._handleConnectivityChange);
+        }
         
         this._processSource(this.props.source);
     }
@@ -217,8 +217,10 @@ class CacheableImage extends React.Component {
 
     renderDefaultSource() {
         const { children, defaultSource, ...props } = this.props;
+	const { children, defaultSource, checkNetwork, ...props } = this.props;
+        const { networkAvailable } = this.state;
         return (
-            <CacheableImage {...props} source={defaultSource}>
+            <CacheableImage {...props} source={defaultSource} checkNetwork={false} networkAvailable={networkAvailable} >
             {children}
             </CacheableImage>
         );
@@ -231,7 +233,9 @@ CacheableImage.propTypes = {
     useQueryParamsInCacheKey: React.PropTypes.oneOfType([
         React.PropTypes.bool,
         React.PropTypes.array
-    ])
+    ]),
+    checkNetwork: React.PropTypes.bool,
+    networkAvailable: React.PropTypes.bool
 };
 
 
@@ -240,5 +244,7 @@ CacheableImage.defaultProps = {
     activityIndicatorProps: {
         style: { backgroundColor: 'transparent', flex: 1 }
     },
-    useQueryParamsInCacheKey: false // bc
+    useQueryParamsInCacheKey: false, // bc
+    checkNetwork: true,
+    networkAvailable: false
 };


### PR DESCRIPTION
**This PR potentially resolves:**
* https://github.com/jayesbe/react-native-cacheable-image/issues/22 (setState warning)
* https://github.com/jayesbe/react-native-cacheable-image/issues/27 (Broken cached image)

**Summary of fixes:**
1. Resolves all instances of `setState` warnings.
2. Solves an issue where an image that is being downloaded in a different component displays as blank space.
3. Solves an issue where downloads were being restarted after every parent update.
4. Fixed a bunch of race conditions related to networking and the delay between javascript & native code.

There is also a possibility that if you render many images that need to be downloaded, and then cause the jobs to be cancelled (for example, by navigating to a different screen), you may get an error from React Native of the form "Callback with id #: undefined.undefined() not found". This is caused by RNFS itself and I have a PR set up here: https://github.com/johanneslumpe/react-native-fs/pull/219

**Here is a walkthrough of the code changes:**
1. Merged in @jayesbe’s changes in the comments of Issue #22 (setState warning), with some help from @robwalkerco.
2. `downloading` and `jobId` are not used in the render functions, and a race condition can cause these to be out of date when using `this.setState()` because it is asynchronous. These have been moved out of the state object.
3. `_processSource()` was erroneously triggering a re-download even when the source URI was identical. Any re-renders in the parent component, or change in network state, were causing the download to be restarted. Comparing the URI property (when present) saves us from accidentally downloading the same image twice.
4. I have re-added a file size check in `checkImageCache()`. This is necessary because on iOS, RNFS creates a zero-byte file when it begins the download. In my application, sometimes a component uses the same URI as another CacheableImage instance. There was a situation where the first component began downloading, and the second one saw the empty file and displayed a blank image. React Native does not update the image when it is changed on disk, so it rendered as transparent.

   The file size check throws an error if there is a zero-byte file, whether it is still downloading or sometime else caused the download operation to not complete. The error starts a new download.  An alternative to this functionality could be to first download the image to a random temporary location until it is completed downloading, but you still might find a race condition while the file is being moved to the final location. Also, that alternative could still result in two downloads of the same image.

   Ideally, RNFS would check to see if it is already downloading a URI, and bind the two jobs into one. But I think this is an edge case overall.
5. Fixed a typo in `RNFS.mkdir().then()` (`_deleteFilePath()`)
6. Added a check to stop an in-progress download before starting a new one in the same component.
7. `RNFS.downloadFile()` immediately returns the `jobId`, so I captured that synchronously. Without this, a race condition exists where the component might unmount before `imageDownloadBegin()` is called, and thus won’t cancel the download job. This can cause a setState warning, not to mention a waste of bandwidth.
8. Because RNFS throws an error when you call `stopDownload()`, I added a check in the error handler to avoid a setState warning. (We only call `stopDownload()` on unmount) It is still necessary to call `_deleteFilePath()` on an error or cancelled download, because RNFS does not remove a partially-downloaded file when this happens.
9. `_handleConnectivityChange()` is now unset in `componentWillUnmount()`, and its status is checked in the initial NetInfo fetch. This solves an issue where a component will quickly mount and then unmount before the initial fetch is resolved. Without this, you may see setState warnings especially if you use local images and accidentally keep `props.checkNetwork == true`.