### PR TITLE
Make background downloads optional and default to off

### DIFF
--- a/image.js
+++ b/image.js
@@ -85,7 +85,7 @@ class CacheableImage extends React.Component {
                 let downloadOptions = {
                     fromUrl: imageUri,
                     toFile: filePath,
-                    background: true,
+                    background: this.props.downloadInBackground,
                     begin: this.imageDownloadBegin,
                     progress: this.imageDownloadProgress
                 };
@@ -231,7 +231,8 @@ CacheableImage.propTypes = {
     useQueryParamsInCacheKey: React.PropTypes.oneOfType([
         React.PropTypes.bool,
         React.PropTypes.array
-    ])
+    ]),
+    downloadInBackground: React.PropTypes.bool
 };
 
 
@@ -240,5 +241,6 @@ CacheableImage.defaultProps = {
     activityIndicatorProps: {
         style: { backgroundColor: 'transparent', flex: 1 }
     },
-    useQueryParamsInCacheKey: false // bc
+    useQueryParamsInCacheKey: false, // bc
+    downloadInBackground: false
 };


### PR DESCRIPTION
On iOS, background downloads are executed in the background, so running several download jobs end up being very slow (see http://stackoverflow.com/a/28229078).

I propose making this parameter optional, and defaulting it to false.