### PR TITLE
Set downloading and jobId

### DIFF
--- a/image.js
+++ b/image.js
@@ -95,17 +95,17 @@ class CacheableImage extends React.Component {
                 .downloadFile(downloadOptions)
                 .promise
                 .then(() => {
-                    this.setState({cacheable: true, cachedImagePath: filePath});
+                    this.setState({downloading: false, jobId: null, cacheable: true, cachedImagePath: filePath});
                 })
                 .catch((err) => {
                     // error occurred while downloading or download stopped.. remove file if created
                     this._deleteFilePath(filePath);
-                    this.setState({cacheable: false, cachedImagePath: null});
+                    this.setState({downloading: false, jobId: null, cacheable: false, cachedImagePath: null});
                 });
             })
             .catch((err) => {
                 this._deleteFilePath(filePath);
-                this.setState({cacheable: false, cachedImagePath: null});
+                this.setState({downloading: false, jobId: null, cacheable: false, cachedImagePath: null});
             })
         });
     }


### PR DESCRIPTION
For small images imageDownloadProgress is never called. On unmounting the component RNFS.stopDownload is called on an already completed download which throws an exception. Fixes [Issue](https://github.com/jayesbe/react-native-cacheable-image/issues/14)