### PR TITLE
Support for placing within TouchableHighlight

### DIFF
--- a/image.js
+++ b/image.js
@@ -41,6 +41,12 @@ class CacheableImage extends React.Component {
         return true;
     }
     
+    setNativeProps(nativeProps) {
+        if (this._imageComponent) {
+            this._imageComponent.setNativeProps(nativeProps);
+        }
+    }
+
     async imageDownloadBegin(info) {
         switch (info.statusCode) {
             case 404:
@@ -256,15 +262,17 @@ class CacheableImage extends React.Component {
             return this.renderDefaultSource();
         }
         
+        const { children, defaultSource, checkNetwork, networkAvailable, downloadInBackground, activityIndicatorProps, ...props } = this.props;
+        const style = [activityIndicatorProps.style, this.props.style];
         return (
-            <ActivityIndicator {...this.props.activityIndicatorProps} />
+            <ActivityIndicator {...props} {...activityIndicatorProps} style={style} />
         );
     }
 
     renderCache() {
         const { children, defaultSource, checkNetwork, networkAvailable, downloadInBackground, activityIndicatorProps, ...props } = this.props;
         return (
-            <ResponsiveImage {...props} source={{uri: 'file://'+this.state.cachedImagePath}}>
+            <ResponsiveImage {...props} source={{uri: 'file://'+this.state.cachedImagePath}} ref={component => this._imageComponent = component}>
             {children}
             </ResponsiveImage>
         );
@@ -273,7 +281,7 @@ class CacheableImage extends React.Component {
     renderLocal() {
         const { children, defaultSource, checkNetwork, networkAvailable, downloadInBackground, activityIndicatorProps, ...props } = this.props;
         return (
-            <ResponsiveImage {...props}>
+            <ResponsiveImage {...props} ref={component => this._imageComponent = component}>
             {children}
             </ResponsiveImage>
         );
@@ -282,7 +290,7 @@ class CacheableImage extends React.Component {
     renderDefaultSource() {
         const { children, defaultSource, checkNetwork, networkAvailable, ...props } = this.props;        
         return (
-            <CacheableImage {...props} source={defaultSource} checkNetwork={false} networkAvailable={this.networkAvailable} >
+            <CacheableImage {...props} source={defaultSource} checkNetwork={false} networkAvailable={this.networkAvailable} ref={component => this._imageComponent = component}>
             {children}
             </CacheableImage>
         );


### PR DESCRIPTION
Changes are based off of this: https://facebook.github.io/react-native/docs/direct-manipulation.html#composite-components-and-setnativeprops

`{...props}` need to be passed into `<ActivityIndicator>`. The way this works here (keeping the original code style) has two new side side-effects:

1) `styles` from `<CacheableImage>` are passed into `<ActivityIndicator>` (This may not be necessary though?)
2) `children` of `<CacheableImage>` are no longer rendered when the `<ActivityIndicator>` is showing

Regarding the second point: While the `<ActivityIndicator>` was displaying, the children of my `<CacheableImage>` were being layed-out strangely. AFAIK `<ActivityIndicator>`s cannot have children, so the child components were being displayed _after_ the `<ActivityIndicator>` as opposed to inside of it. (Then once the images would load, everything adjusted to normal.)

This quick fix just removes the children completely to prevent the temporary weird layouts. A better long-term solution might be to use a placeholder view (defined as a property?) instead of `<ActivityIndicator>` that accepts children like `<Image>` does.

Note also: This requires `react-native-responsive-image` release [2.0.2](https://github.com/Dharmoslap/react-native-responsive-image/releases/tag/2.0.2)

Fixes issue #40 