### PR TITLE
Fix for missing images

### DIFF
--- a/image.js
+++ b/image.js
@@ -241,6 +241,9 @@ class CacheableImage extends React.Component {
 
     async _handleConnectivityChange(isConnected) {
         this.networkAvailable = isConnected;
+        if (this.networkAvailable && this.state.isRemote && !this.state.cachedImagePath) {
+            this._processSource(this.props.source);
+        }
     };
   
     render() {        


### PR DESCRIPTION
If the network is reported as unavailable when the component is mounted, the download process is cancelled. But when the network becomes available again, there was no mechanism to trigger a download. The result was images that never load.

This is most apparent when displaying many images right at app launch, on an iOS device, in release build mode, and without a debugger attached (convoluted, I know).

This PR triggers a download if the network availability has changed and the image has not yet been downloaded.