### PR TITLE
Set "react-native-response-image" dependency to ^2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "crypto-js": "^3.1.6",
     "react-native-fs": "^2.0.1-rc.2",
     "url-parse": "^1.1.1",
-    "react-native-responsive-image": "^1.2.0"
+    "react-native-responsive-image": "^2.2.0"
   }
 }


### PR DESCRIPTION
It would be useful to have version 2 of `react-native-response-image` within `react-native-cacheable-image` as various upgrades have been applied to props applied the raw `<Image />` component that the responsive image uses. As cacheable image only passes the props through to responsive image, I think there should be no compatibility issues, since they have not removed any of the original props, only added more.

I need this for example to pass the `borderRadius` prop down to the raw react-native `<Image />` which with the current dependencies is not possible.