### PR TITLE
Add Support to RN 0.60 by changing import of NetInfo

### DIFF
--- a/image.js
+++ b/image.js
@@ -1,8 +1,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Image, ActivityIndicator, NetInfo, Platform } from 'react-native';
+import { Image, ActivityIndicator, Platform } from 'react-native';
 import RNFS, { DocumentDirectoryPath } from 'react-native-fs';
 import ResponsiveImage from 'react-native-responsive-image';
+
+// support RN 0.60
+import NetInfo from "@react-native-community/netinfo";
 
 const SHA1 = require("crypto-js/sha1");
 const URL = require('url-parse');

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "prop-types": "^15.5.10",
     "react-native-fs": "^2.3.0",
     "react-native-responsive-image": "^2.0.0",
-    "url-parse": "^1.1.1"
+    "url-parse": "^1.1.1",
+    "@react-native-community/netinfo": "^4.1.5"
   }
 }


### PR DESCRIPTION
NetInfo now come from "react-native-community/netinfo" and not from "React Native"